### PR TITLE
feat: implement Redis caching for MealDB search results

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,8 @@ COPY . .
 # Expose port 80 for HTTP traffic
 EXPOSE 80
 
+# Set default Redis URL for local development
+ENV REDIS_URL=redis://localhost:6379
+
 # Run the FastAPI app with Uvicorn
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/app/api/cache.py
+++ b/app/api/cache.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, HTTPException
+from typing import Dict, Any
+from app.services.cache_service import CacheService
+
+router = APIRouter(prefix="/cache", tags=["cache"])
+
+# Initialize cache service
+cache_service = CacheService()
+
+
+@router.get("/stats")
+def get_cache_stats() -> Dict[str, Any]:
+    """Get Redis cache statistics"""
+    stats = cache_service.get_cache_stats()
+    return {
+        "cache_stats": stats,
+        "message": "Cache statistics retrieved successfully"
+    }
+
+
+@router.delete("/clear")
+def clear_cache() -> Dict[str, str]:
+    """Clear all cached data"""
+    success = cache_service.clear_cache()
+    if success:
+        return {"message": "Cache cleared successfully"}
+    else:
+        raise HTTPException(status_code=500, detail="Failed to clear cache")

--- a/app/core/app.py
+++ b/app/core/app.py
@@ -1,18 +1,19 @@
 from fastapi import FastAPI
-from app.api import health, recipes
+from app.api import health, recipes, cache
 
 
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application"""
     app = FastAPI(
         title="Recipe Discovery API",
-        description="A simple recipe management API",
+        description="A simple recipe management API with Redis caching",
         version="1.0.0"
     )
     
     # Include routers
     app.include_router(health.router)
     app.include_router(recipes.router)
+    app.include_router(cache.router)
     
     return app
 

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,7 +1,9 @@
+import os
 from fastapi import Depends
 from app.repositories.recipe_repository import RecipeRepository, InMemoryRecipeRepository
 from app.repositories.sqlite_recipe_repository import SQLiteRecipeRepository
 from app.services.recipe_service import RecipeService
+from app.services.mealdb_service import MealDBService
 
 
 def get_recipe_repository() -> RecipeRepository:
@@ -9,6 +11,15 @@ def get_recipe_repository() -> RecipeRepository:
     return SQLiteRecipeRepository()
 
 
-def get_recipe_service(repository: RecipeRepository = Depends(get_recipe_repository)) -> RecipeService:
+def get_mealdb_service() -> MealDBService:
+    """Dependency to get MealDB service instance with Redis caching"""
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
+    return MealDBService(redis_url=redis_url)
+
+
+def get_recipe_service(
+    repository: RecipeRepository = Depends(get_recipe_repository),
+    mealdb_service: MealDBService = Depends(get_mealdb_service)
+) -> RecipeService:
     """Dependency to get recipe service instance"""
-    return RecipeService(repository)
+    return RecipeService(repository, mealdb_service)

--- a/app/services/cache_service.py
+++ b/app/services/cache_service.py
@@ -1,0 +1,62 @@
+import json
+import redis
+from typing import List, Dict, Any, Optional
+
+
+class CacheService:
+    """Service for Redis caching operations"""
+    
+    def __init__(self, redis_url: str = "redis://localhost:6379"):
+        self.redis_client = redis.from_url(redis_url, decode_responses=True)
+        self.default_ttl = 24 * 60 * 60  # 24 hours in seconds
+    
+    def get_cached_search_results(self, query: str) -> Optional[List[Dict[str, Any]]]:
+        """Get cached search results for a query"""
+        try:
+            cache_key = f"mealdb_search:{query.lower().strip()}"
+            cached_data = self.redis_client.get(cache_key)
+            
+            if cached_data:
+                return json.loads(cached_data)
+            return None
+            
+        except (redis.RedisError, json.JSONDecodeError) as e:
+            print(f"Cache get error: {e}")
+            return None
+    
+    def cache_search_results(self, query: str, results: List[Dict[str, Any]]) -> bool:
+        """Cache search results for a query"""
+        try:
+            cache_key = f"mealdb_search:{query.lower().strip()}"
+            json_data = json.dumps(results)
+            
+            # Set with 24-hour TTL
+            self.redis_client.setex(cache_key, self.default_ttl, json_data)
+            return True
+            
+        except (redis.RedisError, TypeError) as e:
+            print(f"Cache set error: {e}")
+            return False
+    
+    def clear_cache(self) -> bool:
+        """Clear all cached data"""
+        try:
+            self.redis_client.flushdb()
+            return True
+        except redis.RedisError as e:
+            print(f"Cache clear error: {e}")
+            return False
+    
+    def get_cache_stats(self) -> Dict[str, Any]:
+        """Get cache statistics"""
+        try:
+            info = self.redis_client.info()
+            return {
+                "connected_clients": info.get("connected_clients", 0),
+                "used_memory_human": info.get("used_memory_human", "0B"),
+                "keyspace_hits": info.get("keyspace_hits", 0),
+                "keyspace_misses": info.get("keyspace_misses", 0)
+            }
+        except redis.RedisError as e:
+            print(f"Cache stats error: {e}")
+            return {}

--- a/app/services/recipe_service.py
+++ b/app/services/recipe_service.py
@@ -5,9 +5,9 @@ from app.services.mealdb_service import MealDBService
 
 
 class RecipeService:
-    def __init__(self, repository: RecipeRepository):
+    def __init__(self, repository: RecipeRepository, mealdb_service: MealDBService):
         self.repository = repository
-        self.mealdb_service = MealDBService()
+        self.mealdb_service = mealdb_service
 
     def get_all_recipes(self) -> List[Dict[str, Any]]:
         """Get all recipes"""
@@ -26,7 +26,7 @@ class RecipeService:
         for recipe in internal_recipes:
             recipe["source"] = "internal"
         
-        # Get MealDB recipes
+        # Get MealDB recipes (with caching)
         mealdb_recipes = self.mealdb_service.search_recipes(query)
         
         # Combine results (internal first, then MealDB)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    ports:
+      - "8000:80"
+    depends_on:
+      - redis
+    environment:
+      - REDIS_URL=redis://redis:6379
+    networks:
+      - recipe-network
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    networks:
+      - recipe-network
+
+volumes:
+  redis-data:
+
+networks:
+  recipe-network:
+    driver: bridge

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pydantic==2.5.0
 requests==2.31.0
 pytest==8.4.1
 httpx==0.25.2
+redis==5.0.1

--- a/test_integration.py
+++ b/test_integration.py
@@ -4,12 +4,14 @@ from fastapi import FastAPI
 from app.core.app import create_app
 from app.repositories.recipe_repository import InMemoryRecipeRepository
 from app.services.recipe_service import RecipeService
+from app.services.mealdb_service import MealDBService
 from app.dependencies import get_recipe_service
 
 
 # Create a shared test repository that persists across requests
 test_repository = InMemoryRecipeRepository()
-test_service = RecipeService(test_repository)
+test_mealdb_service = MealDBService(redis_url="redis://localhost:6379")
+test_service = RecipeService(test_repository, test_mealdb_service)
 
 
 def get_test_recipe_service():


### PR DESCRIPTION
- Create docker-compose.yml with Redis service for container orchestration
- Add CacheService for Redis operations with 24-hour TTL
- Update MealDBService to use caching with cache-first strategy
- Add cache management endpoints (/cache/stats, /cache/clear)
- Update dependencies to use environment variables for Redis URL
- Cache only MealDB results (SQLite remains uncached for performance)
- Cache keys include search query terms for precise matching
- Add Redis dependency to requirements.txt
- Update Dockerfile to handle Redis environment variable

Performance improvements:
- Cache hits avoid external API calls (verified in testing)
- 24-hour TTL for recipe data (rarely changes)
- Cache statistics show hits/misses for monitoring
- Graceful error handling for Redis connection issues

Testing results:
- Cache MISS on first request (API call made)
- Cache HIT on subsequent requests (no API call)
- Cache clear functionality works correctly
- All existing functionality preserved

Fixes: #20 